### PR TITLE
Fixes complex combination filters

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: node_js
 node_js:
-- "8"
 - "10"
+- "12"
 script:
 - npm run build
 cache:

--- a/src/CqlParser.spec.ts
+++ b/src/CqlParser.spec.ts
@@ -88,6 +88,51 @@ describe('CqlParser', () => {
         ]
       );
     });
+    it('can read complex Combination Filters with parens', () => {
+      const cqlFilter1 = '(Name = Peter OR Name = Hilde) AND Age = 12';
+      const cqlFilter2 = '(Age = 13 OR Name = Peter) AND (Age = 13 OR Name = Hilde)';
+      const cqlFilter3 = '(Age = 12 AND Name = Peter) OR (Age = 12 AND Name = Hilde)';
+      const got1 = cqlParser.read(cqlFilter1);
+      const got2 = cqlParser.read(cqlFilter2);
+      const got3 = cqlParser.read(cqlFilter3);
+      expect(got1).toEqual(
+        [
+          '&&', [
+            '||',
+            ['==', 'Name', 'Peter'],
+            ['==', 'Name', 'Hilde']
+          ],
+          ['==', 'Age', 12]
+        ]
+      );
+      expect(got2).toEqual(
+        [
+          '&&', [
+            '||',
+            ['==', 'Age', 13],
+            ['==', 'Name', 'Peter']
+          ], [
+            '||',
+            ['==', 'Age', 13],
+            ['==', 'Name', 'Hilde']
+          ]
+        ]
+      );
+      expect(got3).toEqual(
+        [
+          '||', [
+            '&&',
+            ['==', 'Age', 12],
+            ['==', 'Name', 'Peter']
+          ], [
+            '&&',
+            ['==', 'Age', 12],
+            ['==', 'Name', 'Hilde']
+          ]
+        ]
+      );
+
+    });
   });
 
   describe('#write', () => {
@@ -144,6 +189,47 @@ describe('CqlParser', () => {
       const cqlFilter1 = 'Age = 12 AND Name = \'Peter\' AND Car = \'Bentley\'';
       const got1 = cqlParser.write(geoStylerFilter1);
       expect(got1).toEqual(cqlFilter1);
+    });
+    it('can write complex Combination Filters', () => {
+      const geoStylerFilter1 = [
+        '&&', [
+          '||',
+          ['==', 'Name', 'Peter'],
+          ['==', 'Name', 'Hilde']
+        ],
+        ['==', 'Age', 12]
+      ];
+      const geoStylerFilter2 = [
+        '&&', [
+          '||',
+          ['==', 'Age', 13],
+          ['==', 'Name', 'Peter']
+        ], [
+          '||',
+          ['==', 'Age', 13],
+          ['==', 'Name', 'Hilde']
+        ]
+      ];
+      const geoStylerFilter3 = [
+        '||', [
+          '&&',
+          ['==', 'Age', 12],
+          ['==', 'Name', 'Peter']
+        ], [
+          '&&',
+          ['==', 'Age', 12],
+          ['==', 'Name', 'Hilde']
+        ]
+      ];
+      const cqlFilter1 = '(Name = \'Peter\' OR Name = \'Hilde\') AND Age = 12';
+      const cqlFilter2 = '(Age = 13 OR Name = \'Peter\') AND (Age = 13 OR Name = \'Hilde\')';
+      const cqlFilter3 = '(Age = 12 AND Name = \'Peter\') OR (Age = 12 AND Name = \'Hilde\')';
+      const got1 = cqlParser.write(geoStylerFilter1);
+      const got2 = cqlParser.write(geoStylerFilter2);
+      const got3 = cqlParser.write(geoStylerFilter3);
+      expect(got1).toEqual(cqlFilter1);
+      expect(got2).toEqual(cqlFilter2);
+      expect(got3).toEqual(cqlFilter3);
     });
   });
 });


### PR DESCRIPTION
This introduces parantheses for complex combination filters. This will fix the reading and writing of multilevel filters like this one:

**GeoStyler**:
```js
[
  '||',
  [
    '&&',
    ['==', 'Age', 12],
    ['==', 'Name', 'Peter']
  ],
  [
    '&&',
    ['==', 'Age', 12],
    ['==', 'Name', 'Hilde']
  ]
]
```
**CQL**:
```js
"(Age = 13 AND Name = 'Peter') OR (Age = 13 AND Name = 'Hilde')"
```

This also updates the travis.yml to use v10 & v12 instead v8 & v10.


@terrestris/devs please review